### PR TITLE
fix: Link to the correct website for Integrated Worlds GmbH

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ helpful-links:
 
 ---
 
-I'm a **CTO at [Integrated Worlds GmbH](https://www.integratedworlds.com/)** with nearly 20 years shipping .NET systems. I've built things that work, broken things that seemed clever, and learned the hard way which lessons actually stick.
+I'm a **CTO at [Integrated Worlds GmbH](https://www.integrated-worlds.com/)** with nearly 20 years shipping .NET systems. I've built things that work, broken things that seemed clever, and learned the hard way which lessons actually stick.
 
 I lead cloud architecture on Azure while staying hands-on: code reviews, production debugging, and the consequences of my own decisions keep me honest. I'm skeptical of buzzword-driven development and allergic to cargo-cult practices. If a trend lacks substance or a pattern collapses under real load, I'll say so.
 


### PR DESCRIPTION
Currently, the website link for Integrated Worlds GmbH incorrectly points to [`https://www.integratedworlds.com/`](https://www.integratedworlds.com/), which is currently up for sale. 

After cross-referencing with your LinkedIn profile, it looks like the correct URL should be [`https://www.integrated-worlds.com/`](https://www.integrated-worlds.com/) _(with a hyphen)_.

This PR updates the link accordingly :)